### PR TITLE
fix: Improve sorting logic for good first issues and stars

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,15 +313,15 @@ class RepositoryContainer {
 }
 
 function sortByGoodFirstIssues(repos) {
-
-       function compare(a, b) {
-           return returnComp(a.issues.length, b.issues.length, a.starcount, b.starcount) 
-	};
-
-
-        repos.sort(compare);
-	return repos; 
+  repos.sort((a, b) => {
+    if (b.issues.length === a.issues.length) {
+      return b.starcount - a.starcount; // Tie-breaker
+    }
+    return b.issues.length - a.issues.length;
+  });
+  return repos;
 }
+
 
 function returnComp(a, b,  tiebreaker1, tiebreaker2) {
 		
@@ -341,13 +341,10 @@ function returnComp(a, b,  tiebreaker1, tiebreaker2) {
 
 
 function sortByStars(repos) {
-	function compare(a, b) {
-		return returnComp(a.starcount, b.starcount, a.issues.length, b.issues.length)
-        };
-
-        repos.sort(compare);
-        return repos;
+  repos.sort((a, b) => b.starcount - a.starcount);
+  return repos;
 }
+
 
 
 function sortBy(value, repositories) {


### PR DESCRIPTION
** ### What Changed**
- Updated the logic for sorting repositories by number of issues or star count.
- Changed the sorting function `sortByGoodFirstIssues` to prioritize sorting by the number of issues first and use stars as a tie-breaker.
- Updated the `sortByStars` function to sort repositories only by star count.

 **### Why This Change?**
These changes improve the logic for prioritizing repositories in lists of "good first issues," making it easier to discover useful projects.

 **### Changes Made**
- Improved logic in `sortByGoodFirstIssues`:
  - Sorts repositories by issue count, with star count as a tie-breaker.
- Improved logic in `sortByStars`:
  - Sorts repositories only by star count in descending order.

---

**### How to Test**
1. Check the sorting behavior with sample repository data.
2. Validate that the changes align with expected sorting behavior.
